### PR TITLE
Update to README.md to update the helm install

### DIFF
--- a/K4K8S+AWSAppMesh/README.md
+++ b/K4K8S+AWSAppMesh/README.md
@@ -168,7 +168,8 @@ We will use Helm to add the kong chart repository and install Kong for Kubernete
 
 helm repo add kong https://charts.konghq.com 
 helm repo update 
-helm install -n kong kong kong/kong --version "1.11.0" --set ingressController.installCRDs=false
+helm install -n kong kong kong/kong --version "2.X.0" --set ingressController.installCRDs=false
+- Note: 2.X.0 should at least 2.1.0
 By default App Mesh will not allow egress from the nodes except to the nodes that are explicitly defined in the mesh. This will prevent the ingress controller container to communicate with the API server, so the deployment of the Kong pod will be failing. To address this aspect, we will use an App Mesh feature, which allows to bypass egress filtering for containers running under security context with (by default) UID 1337. Setting this security context option for the ingress-controller enables it to communicate with the API server, while the rest of the nodes in the service mesh will be restricted to communicate only with the nodes that are defined in the mesh:
 
 kubectl patch deploy -n kong kong-kong -p '{"spec":{"template":{"spec":{"containers":[{"name":"ingress-controller","securityContext":{"runAsUser": 1337}}]}}}}'


### PR DESCRIPTION
```helm install -n kong kong kong/kong --version "1.11.0" --set ingressController.installCRDs=false```
- this command will cause image pull failures:

```
  Warning  Failed     8s (x2 over 22s)   kubelet            Failed to pull image "kong-docker-kubernetes-ingress-controller.bintray.io/kong-ingress-controller:1.0": rpc error: code = Unknown desc = Error response from daemon: error parsing HTTP 403 response body: invalid character '<' looking for beginning of value: "<html>\r\n<head><title>403 Forbidden</title></head>\r\n<body bgcolor=\"white\">\r\n<center><h1>403 Forbidden</h1></center>\r\n<hr><center>nginx</center>\r\n</body>\r\n</html>\r\n"
  Normal   Pulling    8s (x2 over 22s)   kubelet            Pulling image "kong-docker-kubernetes-ingress-controller.bintray.io/kong-ingress-controller:1.0"
```
According to the chart repo [here](https://github.com/Kong/charts/blob/kong-2.2.0/charts/kong/CHANGELOG.md), there was a change done in 2.1.0:
- `Updated default image versions and completed migration off Bintray repositories. (#349)`

This would mean version 1.11 would fail as seen above. 

The README needs to be updated to use at least 2.1.0 as per the changelog. Probably best to recommend the latest version of the chart which is in this case 2.2.0.